### PR TITLE
added install rule for sick_scan2_lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,10 @@ install(TARGETS
   sick_generic_caller
   DESTINATION lib/${PROJECT_NAME})
 
+install(TARGETS
+  sick_scan2_lib
+  DESTINATION lib)
+
 # Install launch files.
 install(DIRECTORY
         launch

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ mkdir -p ~/sick_scan_ws/src/
 cd ~/sick_scan_ws/src/
 git clone https://github.com/SICKAG/sick_scan2.git
 cd ..
-colcon build --symlink-install
+colcon build
 source ~/sick_scan_ws/install/setup.bash
 ```
 
@@ -130,7 +130,7 @@ git clone https://github.com/SICKAG/libsick_ldmrs.git
 git clone https://github.com/SICKAG/sick_scan2.git
 cd ..
 export BUILD_WITH_LDMRS_SUPPORT=True
-colcon build --symlink-install --cmake-args " -DBUILD_WITH_LDMRS_SUPPORT=$BUILD_WITH_LDMRS_SUPPORT"
+colcon build --cmake-args " -DBUILD_WITH_LDMRS_SUPPORT=$BUILD_WITH_LDMRS_SUPPORT"
 source ~/sick_scan_ws/install/setup.bash
 ```
 


### PR DESCRIPTION
If package is built using `colcon` without `--symlink-install` option, `sick_scan2_lib` can't be found, because it is not copied to `install` directory. 

Install rule in `CMakeLists.txt` file fixes this problem. 